### PR TITLE
[Add]会員の注文履歴のページを作成

### DIFF
--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -1,12 +1,15 @@
 class Admins::OrdersController < Admins::Base
   def index
-    @orders = Order.all
-    @order_items = OrderItem.all
+    @all_order = Order.all
   end
 
   def show
     @order = Order.find(params[:id])
     @order_item = OrderItem.find(params[:id])
+  end
+
+  def confirm
+    @member_order = Member.find(params[:member_id])
   end
 
   def update

--- a/app/controllers/admins/tops_controller.rb
+++ b/app/controllers/admins/tops_controller.rb
@@ -1,7 +1,6 @@
 class Admins::TopsController < Admins::Base
   def top
-    @order_item = OrderItem.where("created_at >= ?", Date.today)
+    @today_order = Order.where(created_at: Date.today.all_day)
   end
-
 
 end

--- a/app/views/admins/members/show.html.erb
+++ b/app/views/admins/members/show.html.erb
@@ -3,7 +3,6 @@
     <div class="col-xs-1"></div>
     <div class="col-xs-10">
       <%= "#{@member.last_name} #{@member.first_name}さんの会員詳細" %>
-
       <table class="table table-bordered">
         <tr>
           <td><%= "顧客ID" %></td>
@@ -38,9 +37,8 @@
           <td><%= @member.email %></td>
         </tr>
       </table>
-
-      <%= link_to "編集する", edit_admins_member_path(@member.id), class: "btn btn-primary" %>
-      <%= link_to "注文履歴一覧を見る", edit_admins_member_path, class: "btn btn-primary" %>
+      <%= link_to "編集する", edit_admins_member_path(@member), class: "btn btn-primary" %>
+      <%= link_to "注文履歴一覧を見る", admins_member_orders_confirm_path(@member), class: "btn btn-primary" %>
     </div>
     <div class="col-xs-1"></div>
   </div>

--- a/app/views/admins/orders/confirm.html.erb
+++ b/app/views/admins/orders/confirm.html.erb
@@ -1,4 +1,4 @@
-<h2>〜さんの注文履歴一覧</h2>
+<h2><%= "#{@member_order.last_name} #{@member_order.first_name}さんの注文履歴一覧" %></h2>
 <div class="row">
   <div class="col-xs-10">
     <table class="table table-hover table-inverse">

--- a/app/views/admins/orders/confirm.html.erb
+++ b/app/views/admins/orders/confirm.html.erb
@@ -1,5 +1,4 @@
-<h1><%= "本日の注文数#{@today_order.count}件" %></h1>
-
+<h2>〜さんの注文履歴一覧</h2>
 <div class="row">
   <div class="col-xs-10">
     <table class="table table-hover table-inverse">
@@ -12,9 +11,9 @@
         </tr>
       </thead>
       <tbody>
-        <% @today_order.each do |order| %>
+        <% @member_order.orders.each do |order| %>
         <tr>
-          <td><%= link_to "#{l order.created_at}", admins_order_path(order.id) %></td>
+          <td><%=link_to "#{l order.created_at}", admins_order_path(order.id) %></td>
           <td><%= "#{order.member.last_name} #{order.member.first_name}" %></td>
           <td><%= order.order_items.sum(:amount) %></td>
           <td><%= order.order_status %></td>

--- a/app/views/admins/orders/index.html.erb
+++ b/app/views/admins/orders/index.html.erb
@@ -11,12 +11,12 @@
         </tr>
       </thead>
       <tbody>
-        <% @order_items.each do |order| %>
+        <% @all_order.each do |order| %>
         <tr>
-          <td><%=link_to "#{l order.created_at}", admins_order_path(order.id) %></td>
-          <td><%= order.order.name %></td>
-          <td><%= order.amount %></td>
-          <td><%= order.making_status %></td>
+          <td><%= link_to "#{l order.created_at}", admins_order_path(order.id) %></td>
+          <td><%= "#{order.member.last_name} #{order.member.first_name}" %></td>
+          <td><%= order.order_items.sum(:amount) %></td>
+          <td><%= order.order_status %></td>
         </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,9 @@ Rails.application.routes.draw do
     resources :order_items, only: [:update]
     resources :items, only: [:index, :show, :edit, :update, :create, :new]
     resources :genres, only: [:index, :edit, :update, :create]
-    resources :members, only: [:index, :show, :edit, :update]
+    resources :members, only: [:index, :show, :edit, :update] do
+    get "orders/confirm"
+    end
   end
 
   scope module: :admins do #URLがadmins_admins_sign_inのように冗長にならないようにscope muduleを使用


### PR DESCRIPTION
orderコントローラ、ビューに加えて、routesにconfirmを追加。（該当会員の注文履歴）
order/index　→　全会員の注文履歴
order/confirm　→　該当会員の注文履歴（memberにネストしたらURL長くなっちゃいました）
admins/top　→　本日の注文履歴（timezoneの設定だと思いますが日本時間で取得できていないような気がします）

メンターに相談した結果、注文履歴の3パターンをif文で条件分岐するのは困難だと判断したためそれぞれのページを作成することにしました。